### PR TITLE
Use protocol-relative URL for jQuery script

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -42,7 +42,7 @@
     </div>
 
     {{!-- jQuery needs to come before `{{ghost_foot}}` so that jQuery can be used in code injection --}}
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.12.0.min.js"></script>
+    <script type="text/javascript" src="//code.jquery.com/jquery-1.12.0.min.js"></script>
     {{!-- Ghost outputs important scripts and data with this tag --}}
     {{ghost_foot}}
     {{!-- Fitvids makes video embeds responsive and awesome --}}


### PR DESCRIPTION
Use protocol-relative URL in the script element that includes jQuery to improve availability and consistency as it's being used for Google Fonts too.
